### PR TITLE
Reserve changes when toggling editor, remove save

### DIFF
--- a/app/design/adminhtml/default/default/template/npeditor/js.php
+++ b/app/design/adminhtml/default/default/template/npeditor/js.php
@@ -8,6 +8,8 @@
     <?php endif ?>
     function advEditorToggle(elementId) {
         if (CKEDITOR.instances[elementId]) {
+            
+            document.getElementById(elementId).value = CKEDITOR.instances[elementId].getData();
             CKEDITOR.instances[elementId].destroy(true);
 
             return null;
@@ -27,7 +29,8 @@
                 width: '99.5%',
                 toolbarCanCollapse: true,
                 language: '<?php echo Mage::helper('npeditor')->getLanguage() ?>',
-                extraPlugins: extPlugins
+                extraPlugins: extPlugins,
+                removeButtons: 'Save'
             });
             
             //workaround for editor in hidden tab


### PR DESCRIPTION
Update js.php to reserve changes when toggling editor.
Update js.php to remove the save button from the toolbar as it causes a submit fired within the page when using full ckeditor.